### PR TITLE
Require nothing but Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ node_modules
 tmp
 bower_components
 components
+
+# Project settings
+/.idea/

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prepublish": "bower install",
+    "start": "npm install && grunt",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.3.12",
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-connect": "^0.8.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-open": "^0.2.3",

--- a/readme.md
+++ b/readme.md
@@ -11,16 +11,14 @@ TODO
 
 ## Running
 
-Install dependencies with bower and npm. You'll first need to have [bower](http://bower.io/) and [npm](npmjs.org) installed to do so. Then run the following:
+You only need [Node.js](http://nodejs.org/) installed to build and run this application.
+
+This project comes with a grunt task to run a [`connect`]() web server and open up the web browser for you.
+
+To install all dependencies, build and run the app, and open the browser, simply run:
 
 ```
-bower install && npm install
-```
-
-This project comes with a grunt task to runs a [`connect`]() web server and opens up the web browser for you. Just run:
-
-```
-grunt
+npm start
 ```
 
 ## Credit


### PR DESCRIPTION
These changes remove the requirement for the user/developer to install
or run any commands before launching the app.

Specifically, `npm install -g grunt grunt-cli bower; npm install; bower install`
are no longer prerequisites.

All is done with a simple:

```
npm start
```

(obtw, I snuck a `.gitignore` for WebStorm in there too)
