### PR TITLE
update example TodoMVC app to use Reflux >= 0.2.1 [fixes #15]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "todomvc-common": "~0.1.4",
-    "reflux": "~0.1.15",
+    "reflux": "~0.2.1",
     "react": "~0.11.1",
     "lodash": "~2.4.1",
     "react-router": "~0.7.0"

--- a/js/components.jsx.js
+++ b/js/components.jsx.js
@@ -168,11 +168,7 @@
     var TodoApp = React.createClass({
         // this will cause setState({list:updatedlist}) whenever the store does trigger(updatedlist)
         mixins: [Reflux.connect(todoListStore,"list")],
-        getInitialState: function() {
-            return {
-                list: []
-            };
-        },
+
         render: function() {
             return (
                 <div>

--- a/js/store.js
+++ b/js/store.js
@@ -61,7 +61,7 @@
             this.trigger(list); // sends the updated list to all listening components (TodoApp)
         },
         // this will be called by all listening components as they register their listeners
-        getDefaultData: function() {
+        getInitialState: function() {
             var loadedList = localStorage.getItem(localStorageKey);
             if (!loadedList) {
                 // If no list is in localstorage, start out with a default one


### PR DESCRIPTION
Upgraded Reflux to 0.2.1.

This change required `getInitialState` to be removed from `TodoApp` as it made React to throw the following error:
 
```Invariant Violation: mergeObjectsWithNoDuplicateKeys(): Tried to merge two objects with the same key: list```